### PR TITLE
ci: checkout the released commit when publishing to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,7 @@ jobs:
       with:
         fetch-depth: 0
         fetch-tags: true
+        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
     - uses: jdx/mise-action@v4
     - run: mise run ci-build
     - name: Publish package distributions to PyPI


### PR DESCRIPTION
## Summary
- When `publish.yml` runs via `workflow_run` after `release` completes, the default checkout grabs the default branch HEAD — not the commit the release workflow tagged. If anything lands on `main` between the tag push and the publish run, the wrong source is built and uploaded to PyPI.
- Pin the checkout `ref` to `github.event.workflow_run.head_sha`, falling back to `github.sha` for the `push` (tag), `workflow_dispatch`, and `repository_dispatch` triggers where it already points to the right commit.

## Test plan
- [ ] Trigger the release workflow and confirm the `publish` run checks out the tagged commit
- [ ] Manually re-run `publish.yml --ref <tag>` and confirm it still resolves the tag commit via the `github.sha` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)