### PR TITLE
fix: treat missing rendered AAE sidecar as warning

### DIFF
--- a/photree/album/importer/image_capture.py
+++ b/photree/album/importer/image_capture.py
@@ -383,29 +383,17 @@ def _validate_match(
         else []
     )
 
-    # Rendered pair completeness
-    rendered_pair_errors = [
-        *(
-            [
-                ValidationError(
-                    match.selection_file,
-                    f"rendered file exists ({rendered_media[0]}) but no rendered sidecar (IMG_O*.AAE)",
-                )
-            ]
-            if rendered_media and not rendered_sidecars
-            else []
-        ),
-        *(
-            [
-                ValidationError(
-                    match.selection_file,
-                    f"rendered sidecar exists ({rendered_sidecars[0]}) but no rendered media file",
-                )
-            ]
-            if rendered_sidecars and not rendered_media
-            else []
-        ),
-    ]
+    # Rendered sidecar without rendered media is a real error — orphaned edit data
+    rendered_pair_errors = (
+        [
+            ValidationError(
+                match.selection_file,
+                f"rendered sidecar exists ({rendered_sidecars[0]}) but no rendered media file",
+            )
+        ]
+        if rendered_sidecars and not rendered_media
+        else []
+    )
 
     # Live Photo companion validation
     companion_errors = _validate_companion(match) if match.is_live_photo else []
@@ -418,19 +406,31 @@ def _validate_match(
         *companion_errors,
     ]
 
-    # HEIC without AAE is normal for photos without edits — warn, don't block
+    # AAE sidecars are optional in Image Capture exports — warn, don't block.
     orig_heic = [f for f in orig_media if file_ext(f) == ".heic"]
     orig_aae = [f for f in match.orig_files if _is_sidecar(f)]
-    warnings = (
-        [
-            ValidationWarning(
-                match.selection_file,
-                f"original HEIC ({orig_heic[0]}) has no AAE sidecar",
-            )
-        ]
-        if orig_heic and not orig_aae
-        else []
-    )
+    warnings = [
+        *(
+            [
+                ValidationWarning(
+                    match.selection_file,
+                    f"original HEIC ({orig_heic[0]}) has no AAE sidecar",
+                )
+            ]
+            if orig_heic and not orig_aae
+            else []
+        ),
+        *(
+            [
+                ValidationWarning(
+                    match.selection_file,
+                    f"rendered file ({rendered_media[0]}) has no rendered sidecar (IMG_O*.AAE)",
+                )
+            ]
+            if rendered_media and not rendered_sidecars
+            else []
+        ),
+    ]
 
     return errors, warnings
 

--- a/photree/album/importer/testkit/validation.py
+++ b/photree/album/importer/testkit/validation.py
@@ -11,7 +11,7 @@ VALIDATION_ERRORS = [
     ),
     ValidationError(
         "IMG_0410.HEIC",
-        "rendered file exists (IMG_E0410.HEIC) but no rendered sidecar (IMG_O*.AAE)",
+        "rendered sidecar exists (IMG_O0410.AAE) but no rendered media file",
     ),
     ValidationError(
         "IMG_0500.HEIC",

--- a/tests/integration_fs/album/importer/test_image_capture.py
+++ b/tests/integration_fs/album/importer/test_image_capture.py
@@ -154,13 +154,16 @@ class TestValidateImportPlan:
         assert len(errors) == 1
         assert "no matching original" in errors[0].message
 
-    def test_rendered_without_sidecar(self) -> None:
+    def test_rendered_without_sidecar_warns(self) -> None:
+        # Apple Photos sometimes omits IMG_O*.AAE for edited images
+        # (observed with PNG originals re-rendered to JPG). Warn, don't block.
         plan = plan_import(
             ["IMG_0410.HEIC"],
             ["IMG_0410.HEIC", "IMG_0410.AAE", "IMG_E0410.HEIC"],
         )
         errors, warnings = validate_import_plan(plan)
-        assert any("rendered sidecar" in e.message for e in errors)
+        assert not errors
+        assert any("no rendered sidecar" in w.message for w in warnings)
 
     def test_rendered_sidecar_without_rendered_media(self) -> None:
         plan = plan_import(


### PR DESCRIPTION
## Summary
- Demote "rendered file exists but no `IMG_O*.AAE`" from a hard import failure to a warning. Apple Photos exports edited images via Image Capture without the rendered sidecar in some cases (observed with PNG originals re-rendered to JPG), and `internals.md` already documents `IMG_O*.AAE` as optional.
- Mirrors the earlier relaxation of missing original AAE sidecars (commit `15af58e`).
- The inverse case — an orphaned `IMG_O*.AAE` with no `IMG_E*` media — remains an error, since that signals dangling edit metadata.

## Test plan
- [x] `mise run check` (format, lint, type-check, compat, clidocs, depgraph)
- [x] `poetry run pytest tests/integration_fs/album/importer/test_image_capture.py -v` (37 passed)
- [ ] Manually re-run the original failing `album import` against the Perú album to confirm it now proceeds with warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)