### PR TITLE
fix: skip non-album directories in gallery import-all

### DIFF
--- a/photree/album/store/album_discovery.py
+++ b/photree/album/store/album_discovery.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from ...common.fs import matching_subdirectories
+from ...common.fs import matching_subdirectories, partition_subdirectories
 from ...fsprotocol import PHOTREE_DIR
 from .media_sources_discovery import discover_media_sources
 from .protocol import ALBUM_YAML
@@ -41,13 +41,21 @@ def discover_albums(base_dir: Path) -> list[Path]:
     return matching_subdirectories(base_dir, is_album)
 
 
-def discover_potential_albums(base_dir: Path) -> list[Path]:
-    """Recursively discover directories with media sources under *base_dir*.
+def discover_potential_albums(base_dir: Path) -> tuple[list[Path], list[Path]]:
+    """Recursively discover potential albums under *base_dir*.
+
+    Returns ``(albums, skipped)``:
+
+    - *albums*: subdirectories with at least one media source. Recursion
+      stops at each match.
+    - *skipped*: subdirectories traversed during the walk that are not
+      themselves albums (every level above a match plus non-matching
+      leaves).
 
     Unlike :func:`discover_albums`, this does **not** require
-    ``.photree/album.yaml`` — it finds any directory with at least one
-    media source. Useful for ``init`` commands that create ``album.yaml``.
+    ``.photree/album.yaml`` — useful for commands that may create
+    ``album.yaml`` themselves (init, import).
 
-    The *base_dir* itself is never returned.
+    The *base_dir* itself is never returned in either list.
     """
-    return matching_subdirectories(base_dir, has_media_sources)
+    return partition_subdirectories(base_dir, has_media_sources)

--- a/photree/albums/cli/ops.py
+++ b/photree/albums/cli/ops.py
@@ -68,8 +68,12 @@ def resolve_init_batch_albums(
 
     Uses :func:`discover_potential_albums` which finds directories with
     media sources regardless of whether ``.photree/album.yaml`` exists.
+    The skipped (non-album) directories are discarded — ``init`` is
+    indifferent to them.
     """
-    return _resolve_batch_albums_with(base_dir, album_dirs, discover_potential_albums)
+    return _resolve_batch_albums_with(
+        base_dir, album_dirs, lambda d: discover_potential_albums(d)[0]
+    )
 
 
 def _resolve_batch_albums_with(

--- a/photree/common/fs.py
+++ b/photree/common/fs.py
@@ -88,6 +88,39 @@ def matching_subdirectories(
     return list(walk(base_dir))
 
 
+def partition_subdirectories(
+    base_dir: Path, predicate: Callable[[Path], bool]
+) -> tuple[list[Path], list[Path]]:
+    """Recursively partition subdirectories of *base_dir* into matched and skipped.
+
+    Walks the tree like :func:`matching_subdirectories`: when a directory
+    matches *predicate*, it is collected and its subtree is not descended
+    into. Non-matching directories that are traversed (every level above
+    a match, plus non-matching leaves) are collected as *skipped*.
+
+    *base_dir* itself is never returned in either list. Returns
+    ``([], [])`` when *base_dir* does not exist.
+    """
+    if not base_dir.is_dir():
+        return ([], [])
+
+    matched: list[Path] = []
+    skipped: list[Path] = []
+
+    def walk(directory: Path) -> None:
+        if predicate(directory):
+            matched.append(directory)
+            return
+        skipped.append(directory)
+        for child in _visible_subdirs(directory):
+            walk(child)
+
+    for child in _visible_subdirs(base_dir):
+        walk(child)
+
+    return (matched, skipped)
+
+
 def move_files(
     src_dir: Path,
     dst_dir: Path,

--- a/photree/gallery/cli/import_all_cmd.py
+++ b/photree/gallery/cli/import_all_cmd.py
@@ -94,7 +94,18 @@ def import_all_cmd(
     resolved_lm = resolve_link_mode(link_mode, resolved_gallery)
     cwd = Path.cwd()
 
-    albums = resolve_import_all_albums(base_dir, album_dirs)
+    albums, skipped = resolve_import_all_albums(base_dir, album_dirs)
+
+    if skipped:
+        typer.echo(f"Skipped {len(skipped)} non-album director(ies):")
+        for s in skipped:
+            typer.echo(f"  {display_path(s, cwd)}")
+        typer.echo("")
+
+    if not albums:
+        typer.echo("No album directories found.")
+        raise typer.Exit(code=0)
+
     index = build_index_or_exit(resolved_gallery, cwd)
 
     try:

--- a/photree/gallery/cli/ops.py
+++ b/photree/gallery/cli/ops.py
@@ -16,6 +16,7 @@ from ...album import (
 )
 from ...album.check import output as preflight_output
 from ...album.check.output import format_naming_checks
+from ...album.store.album_discovery import discover_potential_albums
 from ...album.store.metadata import load_album_metadata
 from ...album.id import format_album_external_id
 from ...common.fs import display_path
@@ -182,17 +183,20 @@ def print_single_import_result(
 def resolve_import_all_albums(
     base_dir: Path | None,
     album_dirs: list[Path] | None,
-) -> list[Path]:
-    """Resolve album list for batch import from --dir or --album-dir."""
+) -> tuple[list[Path], list[Path]]:
+    """Resolve album list for batch import from --dir or --album-dir.
+
+    Returns ``(albums, skipped)``. When --dir is used, the scan is
+    recursive: *albums* are directories with at least one media source,
+    and *skipped* are non-album directories traversed during the walk.
+    When --album-dir is used, *skipped* is always empty — the user picked
+    those directories explicitly.
+    """
     if album_dirs is not None:
-        return album_dirs
+        return (album_dirs, [])
 
     scan_dir = base_dir if base_dir is not None else Path(".").resolve()
-    albums = sorted(p for p in scan_dir.iterdir() if p.is_dir())
-    if not albums:
-        typer.echo("No album directories found.")
-        raise typer.Exit(code=0)
-    return albums
+    return discover_potential_albums(scan_dir)
 
 
 def run_batch_import(

--- a/tests/integration_fs/fs/test_metadata.py
+++ b/tests/integration_fs/fs/test_metadata.py
@@ -358,18 +358,42 @@ class TestDiscoverPotentialAlbums:
         _setup_media_source(album)
         # No _mark_album — no album.yaml
 
-        result = discover_potential_albums(tmp_path)
-        assert result == [album]
+        albums, skipped = discover_potential_albums(tmp_path)
+        assert albums == [album]
+        assert skipped == []
 
     def test_finds_albums_with_metadata(self, tmp_path: Path) -> None:
         album = tmp_path / "album"
         _setup_media_source(album)
         _mark_album(album)
 
-        result = discover_potential_albums(tmp_path)
-        assert result == [album]
+        albums, skipped = discover_potential_albums(tmp_path)
+        assert albums == [album]
+        assert skipped == []
 
     def test_skips_empty_dirs(self, tmp_path: Path) -> None:
-        (tmp_path / "empty").mkdir()
-        result = discover_potential_albums(tmp_path)
-        assert result == []
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        albums, skipped = discover_potential_albums(tmp_path)
+        assert albums == []
+        assert skipped == [empty]
+
+    def test_partitions_albums_and_non_albums(self, tmp_path: Path) -> None:
+        album = tmp_path / "album"
+        _setup_media_source(album)
+        non_album = tmp_path / "new"
+        non_album.mkdir()
+
+        albums, skipped = discover_potential_albums(tmp_path)
+        assert albums == [album]
+        assert skipped == [non_album]
+
+    def test_skipped_includes_intermediate_levels(self, tmp_path: Path) -> None:
+        container = tmp_path / "trip"
+        container.mkdir()
+        album = container / "album"
+        _setup_media_source(album)
+
+        albums, skipped = discover_potential_albums(tmp_path)
+        assert albums == [album]
+        assert skipped == [container]


### PR DESCRIPTION
## Summary

- `gallery import-all -d <dir>` no longer crashes on the first non-album subdirectory (e.g. `~/Pictures/to-backup/new`). It now scans recursively via `discover_potential_albums`, imports the directories that have media sources, and prints the non-album directories it skipped.
- `discover_potential_albums` returns `(albums, skipped)` instead of just a list. Skipped includes every intermediate non-matching directory traversed during the walk.
- New `common.fs.partition_subdirectories` helper mirrors `matching_subdirectories` but collects the non-matching dirs alongside the matches.

Stacked on #34 — base will switch to `main` once that PR merges.

## Test plan

- [x] `mise run check` clean
- [x] `mise run test-unit` — 198 passed
- [x] `mise run test-integration-fs` — 570 passed (added two new tests covering the partition semantics)
- [x] Manual: `photree gallery import-all -d ~/Pictures/to-backup` reports skipped non-album dirs and imports the rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)